### PR TITLE
Add get testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,17 @@ This repository contains the scripts used to run interface conformance testing f
 
 # Install
 
-To install the script and ready it for use, clone this repo:
+To clone the repository and ready it for use, first clone this repo:
 
 ```bash
-$ git clone https://github.com/ipfs-rust/ipfs-rust-conformance
+$ git clone https://github.com/rs-ipfs/ipfs-rust-conformance
+```
+
+After cloning, use `setup.sh` to do `npm install` and patch any of the dependencies:
+
+```bash
+$ cd ipfs-rust-conformance
+$ ./setup.sh
 ```
 
 # Usage
@@ -26,6 +33,37 @@ $ ln -s /path/to/rust-ipfs/target/ipfs-http ./http
 $ IPFS_RUST_EXEC=$(pwd)/rust.sh npm test
 $ cat /tmp/rust.log
 ```
+
+# Patch management
+
+We currently staying behind at `interface-ipfs-core@0.134.3` and the fixes we have upstreamed are also kept under `patches/`.
+
+To create a new patch:
+
+1. Fork https://github.com/ipfs/js-ipfs/
+2. Clone locally
+3. Checkout a new branch based on the tag for the `interface-ipfs-core` version
+   we are currently depending on (see package.json)
+4. Apply all of our patches from `patches/` with `git apply $ipfs_rust_conformance/patches/*`
+5. Fix any new tests
+6. When done, cherry pick your commits to a new branch based off the latest
+   main js-ipfs branch
+7. Submit PR
+8. Squash your work, refer to your PR in the message
+9. Remove existing `patches/`
+9. Recreate the `patches/` with `git format-patch -o
+   $ipfs-rust-conformance/patches $the_tag_you_based_your_work`
+
+Where above:
+
+ - `$ipfs_rust_conformance` points to your checkout of this repository
+ - `$the_tag_you_based_your_work` is the tag you started working on js-ipfs
+   working copy
+
+Previously this has been done by first working on a patch and then backporting
+it, which might be easier. Luckily the tests are low traffic. If you need help
+wrestling with git, don't hesitate to ask for guidance; this is simpler than
+it's step by step explanation looks like.
 
 # Troubleshooting hangs
 

--- a/patches/0001-refs-tests-per-https-github.com-ipfs-js-ipfs-pull-29.patch
+++ b/patches/0001-refs-tests-per-https-github.com-ipfs-js-ipfs-pull-29.patch
@@ -1,0 +1,59 @@
+From 69cfebbca131cbf8ef0ef7be01fd13d289e6b3f3 Mon Sep 17 00:00:00 2001
+From: Joonas Koivunen <joonas.koivunen@gmail.com>
+Date: Wed, 17 Jun 2020 14:17:23 +0300
+Subject: [PATCH 1/4] refs tests per https://github.com/ipfs/js-ipfs/pull/2982
+
+---
+ packages/interface-ipfs-core/src/refs.js | 27 ++++++++++++------------
+ 1 file changed, 14 insertions(+), 13 deletions(-)
+
+diff --git a/packages/interface-ipfs-core/src/refs.js b/packages/interface-ipfs-core/src/refs.js
+index 1645937a..5ec99ffc 100644
+--- a/packages/interface-ipfs-core/src/refs.js
++++ b/packages/interface-ipfs-core/src/refs.js
+@@ -64,8 +64,9 @@ module.exports = (common, options) => {
+ 
+         const refs = await all(ipfs.refs(p, params))
+ 
++        // Sort the refs not to lock-in the iteration order
+         // Check there was no error and the refs match what was expected
+-        expect(refs.map(r => r.ref)).to.eql(expected)
++        expect(refs.map(r => r.ref).sort()).to.eql(expected.sort())
+       })
+     }
+ 
+@@ -198,19 +199,19 @@ function getRefsTests () {
+     },
+ 
+     'should get refs with recursive and unique option': {
+-      params: { format: '<linkname>', recursive: true, unique: true },
++      params: { format: '<dst>', recursive: true, unique: true },
+       expected: [
+-        'animals',
+-        'land',
+-        'african.txt',
+-        'americas.txt',
+-        'australian.txt',
+-        'sea',
+-        'atlantic.txt',
+-        'indian.txt',
+-        'fruits',
+-        'tropical.txt',
+-        'mushroom.txt'
++        'QmRfqT4uTUgFXhWbfBZm6eZxi2FQ8pqYK5tcWRyTZ7RcgY',
++        'QmUXzZKa3xhTauLektUiK4GiogHskuz1c57CnnoP4TgYJD',
++        'QmVX54jfjB8eRxLVxyQSod6b1FyDh7mR4mQie9j97i2Qk3',
++        'QmWEuXAjUGyndgr4MKqMBgzMW36XgPgvitt2jsXgtuc7JE',
++        'QmYEJ7qQNZUvBnv4SZ3rEbksagaan3sGvnUq948vSG8Z34',
++        'QmYLvZrFn8KE2bcJ9UFhthScBVbbcXEgkJnnCBeKWYkpuQ',
++        'Qma5z9bmwPcrWLJxX6Vj6BrcybaFg84c2riNbUKrSVf8h1',
++        'QmbrFTo4s6H23W6wmoZKQC2vSogGeQ4dYiceSqJddzrKVa',
++        'QmdHVR8M4zAdGctnTYq4fyPZjTwwzdcBpGWAfMAhAVfT9n',
++        'Qmf6MrqT2oAve9diagLTMCYFPEcSx7fnUdW3xAjhXm32vo',
++        'QmfP6D9bRV4FEYDL4EHZtZG58kDwDfnzmyjuyK5d1pvzbM'
+       ]
+     },
+ 
+-- 
+2.20.1
+

--- a/patches/0002-refs-local-tests-per-https-github.com-ipfs-js-ipfs-p.patch
+++ b/patches/0002-refs-local-tests-per-https-github.com-ipfs-js-ipfs-p.patch
@@ -1,0 +1,78 @@
+From b8946ed35c395e4927386882f307bbee340aec87 Mon Sep 17 00:00:00 2001
+From: Joonas Koivunen <joonas.koivunen@gmail.com>
+Date: Wed, 17 Jun 2020 14:19:28 +0300
+Subject: [PATCH 2/4] refs-local tests per
+ https://github.com/ipfs/js-ipfs/pull/2989
+
+---
+ .../interface-ipfs-core/src/refs-local.js     | 44 ++++++++++++++++---
+ 1 file changed, 38 insertions(+), 6 deletions(-)
+
+diff --git a/packages/interface-ipfs-core/src/refs-local.js b/packages/interface-ipfs-core/src/refs-local.js
+index 9c41c7bc..59701260 100644
+--- a/packages/interface-ipfs-core/src/refs-local.js
++++ b/packages/interface-ipfs-core/src/refs-local.js
+@@ -5,6 +5,7 @@ const { fixtures } = require('./utils')
+ const { getDescribe, getIt, expect } = require('./utils/mocha')
+ const all = require('it-all')
+ const importer = require('ipfs-unixfs-importer')
++const CID = require('cids')
+ 
+ /** @typedef { import("ipfsd-ctl/src/factory") } Factory */
+ /**
+@@ -39,15 +40,46 @@ module.exports = (common, options) => {
+ 
+       const imported = await all(importer(dirs, ipfs.block))
+ 
+-      // otherwise go-ipfs doesn't show them in the local refs
+-      await Promise.all(
+-        imported.map(i => ipfs.pin.add(i.cid))
+-      )
++      // rust-ipfs doesn't yet have pinning api, it'll just list all local cids
++      // in /refs/local
++      if (common.opts.type !== 'rust') {
++        // otherwise go-ipfs doesn't show them in the local refs
++        await Promise.all(
++          imported.map(i => ipfs.pin.add(i.cid))
++        )
++      }
+ 
+       const refs = await all(ipfs.refs.local())
++
++      const expected = [
++        'QmVwdDCY4SPGVFnNCiZnX5CtzwWDn6kAM98JXzKxE3kCmn',
++        'QmR4nFjTu18TyANgC65ArNWp5Yaab1gPzQ4D8zp7Kx3vhr'
++      ]
++
+       const cids = refs.map(r => r.ref)
+-      expect(cids).to.include('QmVwdDCY4SPGVFnNCiZnX5CtzwWDn6kAM98JXzKxE3kCmn')
+-      expect(cids).to.include('QmR4nFjTu18TyANgC65ArNWp5Yaab1gPzQ4D8zp7Kx3vhr')
++
++      for (const alt of expected.map(alternatives)) {
++        // allow the cids to be either original or in later cid version.
++        let removed = false
++        for (const version of alt) {
++          const index = cids.indexOf(version)
++          if (index === -1) {
++            continue
++          }
++          removed = true
++          delete cids[index]
++          break
++        }
++        expect(removed, `failed to remove '${alt[0]}'`).to.be.true()
++      }
+     })
+   })
+ }
++
++function alternatives (cidstr) {
++  const cid = new CID(cidstr)
++  if (cid.version === 0) {
++    return [cidstr, cid.toV1().toString()]
++  }
++  return [cidstr]
++}
+-- 
+2.20.1
+

--- a/patches/0003-cat-tests-per-https-github.com-ipfs-js-ipfs-pull-307.patch
+++ b/patches/0003-cat-tests-per-https-github.com-ipfs-js-ipfs-pull-307.patch
@@ -1,0 +1,80 @@
+From 237da167cacd3397885a718645d16b518669ba49 Mon Sep 17 00:00:00 2001
+From: Joonas Koivunen <joonas.koivunen@gmail.com>
+Date: Wed, 17 Jun 2020 14:08:03 +0300
+Subject: [PATCH 3/4] cat tests per https://github.com/ipfs/js-ipfs/pull/3078
+
+---
+ packages/interface-ipfs-core/src/cat.js | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/packages/interface-ipfs-core/src/cat.js b/packages/interface-ipfs-core/src/cat.js
+index 42e8cacd..de7c83d4 100644
+--- a/packages/interface-ipfs-core/src/cat.js
++++ b/packages/interface-ipfs-core/src/cat.js
+@@ -6,6 +6,7 @@ const CID = require('cids')
+ const concat = require('it-concat')
+ const all = require('it-all')
+ const { getDescribe, getIt, expect } = require('./utils/mocha')
++const importer = require('ipfs-unixfs-importer')
+ 
+ /** @typedef { import("ipfsd-ctl/src/factory") } Factory */
+ /**
+@@ -26,8 +27,8 @@ module.exports = (common, options) => {
+     after(() => common.clean())
+ 
+     before(() => Promise.all([
+-      all(ipfs.add(fixtures.smallFile.data)),
+-      all(ipfs.add(fixtures.bigFile.data))
++      all(importer([{ content: fixtures.smallFile.data }], ipfs.block)),
++      all(importer([{ content: fixtures.bigFile.data }], ipfs.block))
+     ]))
+ 
+     it('should cat with a base58 string encoded multihash', async () => {
+@@ -52,7 +53,7 @@ module.exports = (common, options) => {
+     it('should cat a file added as CIDv0 with a CIDv1', async () => {
+       const input = Buffer.from(`TEST${Math.random()}`)
+ 
+-      const res = await all(ipfs.add(input, { cidVersion: 0 }))
++      const res = await all(importer([{ content: input }], ipfs.block))
+ 
+       const cidv0 = res[0].cid
+       expect(cidv0.version).to.equal(0)
+@@ -66,7 +67,7 @@ module.exports = (common, options) => {
+     it('should cat a file added as CIDv1 with a CIDv0', async () => {
+       const input = Buffer.from(`TEST${Math.random()}`)
+ 
+-      const res = await all(ipfs.add(input, { cidVersion: 1, rawLeaves: false }))
++      const res = await all(importer([{ content: input }], ipfs.block, { cidVersion: 1, rawLeaves: false }))
+ 
+       const cidv1 = res[0].cid
+       expect(cidv1.version).to.equal(1)
+@@ -93,7 +94,7 @@ module.exports = (common, options) => {
+     it('should cat with IPFS path, nested value', async () => {
+       const fileToAdd = { path: 'a/testfile.txt', content: fixtures.smallFile.data }
+ 
+-      const filesAdded = await all(ipfs.add([fileToAdd]))
++      const filesAdded = await all(importer([fileToAdd], ipfs.block))
+ 
+       const file = await filesAdded.find((f) => f.path === 'a')
+       expect(file).to.exist()
+@@ -106,7 +107,7 @@ module.exports = (common, options) => {
+     it('should cat with IPFS path, deeply nested value', async () => {
+       const fileToAdd = { path: 'a/b/testfile.txt', content: fixtures.smallFile.data }
+ 
+-      const filesAdded = await all(ipfs.add([fileToAdd]))
++      const filesAdded = await all(importer([fileToAdd], ipfs.block))
+ 
+       const file = filesAdded.find((f) => f.path === 'a')
+       expect(file).to.exist()
+@@ -134,7 +135,7 @@ module.exports = (common, options) => {
+     it('should error on dir path', async () => {
+       const file = { path: 'dir/testfile.txt', content: fixtures.smallFile.data }
+ 
+-      const filesAdded = await all(ipfs.add([file]))
++      const filesAdded = await all(importer([file], ipfs.block))
+       expect(filesAdded.length).to.equal(2)
+ 
+       const files = filesAdded.filter((file) => file.path === 'dir')
+-- 
+2.20.1
+

--- a/patches/0004-get-tests-per-https-github.com-ipfs-js-ipfs-pull-309.patch
+++ b/patches/0004-get-tests-per-https-github.com-ipfs-js-ipfs-pull-309.patch
@@ -1,0 +1,80 @@
+From 9acd415c55f4bc80093af8bcedfa8e9e18e680a7 Mon Sep 17 00:00:00 2001
+From: Joonas Koivunen <joonas.koivunen@gmail.com>
+Date: Wed, 17 Jun 2020 14:08:37 +0300
+Subject: [PATCH 4/4] get tests per https://github.com/ipfs/js-ipfs/pull/3093
+
+---
+ packages/interface-ipfs-core/src/get.js | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/packages/interface-ipfs-core/src/get.js b/packages/interface-ipfs-core/src/get.js
+index f54ef26e..453bf725 100644
+--- a/packages/interface-ipfs-core/src/get.js
++++ b/packages/interface-ipfs-core/src/get.js
+@@ -6,6 +6,7 @@ const CID = require('cids')
+ const all = require('it-all')
+ const concat = require('it-concat')
+ const { getDescribe, getIt, expect } = require('./utils/mocha')
++const importer = require('ipfs-unixfs-importer')
+ 
+ /** @typedef { import("ipfsd-ctl/src/factory") } Factory */
+ /**
+@@ -23,8 +24,8 @@ module.exports = (common, options) => {
+ 
+     before(async () => {
+       ipfs = (await common.spawn()).api
+-      await all(ipfs.add(fixtures.smallFile.data))
+-      await all(ipfs.add(fixtures.bigFile.data))
++      await all(importer([{ content: fixtures.smallFile.data }], ipfs.block))
++      await all(importer([{ content: fixtures.bigFile.data }], ipfs.block))
+     })
+ 
+     after(() => common.clean())
+@@ -48,7 +49,7 @@ module.exports = (common, options) => {
+     it('should get a file added as CIDv0 with a CIDv1', async () => {
+       const input = Buffer.from(`TEST${Math.random()}`)
+ 
+-      const res = await all(ipfs.add(input, { cidVersion: 0 }))
++      const res = await all(importer([{ content: input }], ipfs.block))
+ 
+       const cidv0 = res[0].cid
+       expect(cidv0.version).to.equal(0)
+@@ -62,7 +63,7 @@ module.exports = (common, options) => {
+     it('should get a file added as CIDv1 with a CIDv0', async () => {
+       const input = Buffer.from(`TEST${Math.random()}`)
+ 
+-      const res = await all(ipfs.add(input, { cidVersion: 1, rawLeaves: false }))
++      const res = await all(importer([{ content: input }], ipfs.block, { cidVersion: 1, rawLeaves: false }))
+ 
+       const cidv1 = res[0].cid
+       expect(cidv1.version).to.equal(1)
+@@ -101,7 +102,7 @@ module.exports = (common, options) => {
+         emptyDir('files/empty')
+       ]
+ 
+-      const res = await all(ipfs.add(dirs))
++      const res = await all(importer(dirs, ipfs.block))
+       const root = res[res.length - 1]
+ 
+       expect(root.path).to.equal('test-folder')
+@@ -152,7 +153,7 @@ module.exports = (common, options) => {
+         content: fixtures.smallFile.data
+       }
+ 
+-      for await (const fileAdded of ipfs.add(file)) {
++      for await (const fileAdded of importer([file], ipfs.block)) {
+         if (fileAdded.path === 'a') {
+           const files = await all(ipfs.get(`/ipfs/${fileAdded.cid.toString()}/testfile.txt`))
+           expect(files).to.be.length(1)
+@@ -167,7 +168,7 @@ module.exports = (common, options) => {
+         content: fixtures.smallFile.data
+       }
+ 
+-      const filesAdded = await all(ipfs.add([file]))
++      const filesAdded = await all(importer([file], ipfs.block))
+ 
+       filesAdded.forEach(async (file) => {
+         if (file.path === 'a') {
+-- 
+2.20.1
+

--- a/setup.sh
+++ b/setup.sh
@@ -6,5 +6,11 @@ set -o pipefail
 npm install
 
 if [ -d "patches" ]; then
-    git apply patches/* -p3 --directory node_modules/interface-ipfs-core/
+    echo "Applying patches..."
+    # as we want to apply the patches create in a js-ipfs checkout to our node_modules
+    # we'll need to remove a few leading path segments to match
+    # a/packages/interface-ipfs-core/src/refs.js to node_modules/interface-ipfs-core/src/refs.js
+    #
+    # applying these patches on js-ipfs checkout does not require any extra arguments.
+    git apply --verbose patches/* -p3 --directory node_modules/interface-ipfs-core/
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+npm install
+
+if [ -d "patches" ]; then
+    git apply patches/* -p3 --directory node_modules/interface-ipfs-core/
+fi

--- a/test/index.js
+++ b/test/index.js
@@ -59,6 +59,9 @@ tests.root.refs(factory, {
 tests.root.refsLocal(factory, { skip: ['should get local refs'] });
 
 // Phase 2 and beyond...
+
+tests.root.cat(factory);
+
 // tests.repo(factory)
 // tests.object(factory)
 // tests.pin(factory)

--- a/test/index.js
+++ b/test/index.js
@@ -45,18 +45,8 @@ tests.block(factory, { skip: ['should error when removing pinned blocks'] })
 
 // these are a bit flaky
 tests.bitswap(factory)
-tests.root.refs(factory, {
-  skip: [
-    'should print refs for multiple paths',
-    'should follow a path with max depth 2, <hash>/<subdir>',
-    'should get refs with max depth of 3',
-    'should get refs with max depth of 2',
-    'should get refs with recursive and unique option',
-    'should recursively follows folders, -r',
-    'should follow a path with recursion, <hash>/<subdir>'
-  ]
-});
-tests.root.refsLocal(factory, { skip: ['should get local refs'] });
+tests.root.refs(factory);
+tests.root.refsLocal(factory);
 
 // Phase 2 and beyond...
 

--- a/test/index.js
+++ b/test/index.js
@@ -61,6 +61,7 @@ tests.root.refsLocal(factory, { skip: ['should get local refs'] });
 // Phase 2 and beyond...
 
 tests.root.cat(factory);
+tests.root.get(factory);
 
 // tests.repo(factory)
 // tests.object(factory)


### PR DESCRIPTION
This supercedes the earlier #23. Introduces a way we can have the patches we need without interfering with lerna or any other npm magic. Draft until I've tested this through rust-ipfs workflow.